### PR TITLE
Fix paper trading loop reset

### DIFF
--- a/paper_trading.py
+++ b/paper_trading.py
@@ -114,6 +114,8 @@ def main():
     # Переменная для отслеживания времени последнего дообучения
     last_retrain_time = datetime.utcnow()
 
+    obs, _ = env.reset()
+
     while True:
         current_time = datetime.utcnow()
 
@@ -128,10 +130,9 @@ def main():
         df = update_market_data(df)
         env.df = df
 
-        obs, _ = env.reset()
         action, _ = model.predict(obs, deterministic=True)
         logging.info(f"Predicted action: {action}")
-        
+
         obs, reward, terminated, truncated, info = env.step(action)
         logging.info(f"Reward: {reward}, Balance: {env.balance}")
 


### PR DESCRIPTION
## Summary
- keep environment state across iterations in the paper trading script

## Testing
- `python -m py_compile environment.py train_rl.py paper_trading.py get_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd310a2248326ae14148389a76392