### PR TITLE
Refactor trading environment and add data/tuning utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository demonstrates how to train a reinforcement learning (RL) agent using [Stable-Baselines3](https://github.com/DLR-RM/stable-baselines3) for trading on hourly candlestick data. The project consists of:
 
-- A custom Gymnasium environment (**environment.py**) that simulates trading with:
+- A custom Gymnasium environment (**env/hourly_trading_env.py**) that simulates trading with:
   - Multi-bar holding (positions can stay open across multiple time steps).
   - Stop-Loss and Take-Profit checks at each bar.
   - Commission and slippage modeling.
@@ -31,10 +31,10 @@ This repository demonstrates how to train a reinforcement learning (RL) agent us
 ### 1. **Configuration**
 The model parameters are defined in `config.json`:
 - `window_size`: Number of data points in a sequence.
-- `num_features`: Features per data point (e.g., `high`, `low`, `close`, etc.).
 - `model_name`: File name for saving and loading the model.
 - `data_file`: CSV file containing historical data.
 - `initial_balance`, `trade_risk`, `min_balance`, etc.: Parameters for simulated trading.
+- `data_top_n`, `data_interval`, `data_start_date`, `data_end_date`, `data_output_file`: Parameters for downloading market history for the most traded pairs.
 
 ### 2. **Data Preparation**
 The model processes historical market data:
@@ -100,8 +100,8 @@ python train_rl.py
 
 ## Example Workflow
 
-1. Collect hourly historical data for a trading pair (e.g., BTC/USDT) using an API or CSV file.
-2. Configure the model with `window_size = 168` and `num_features = 5`.
+1. Collect hourly historical data for a trading pair (e.g., BTC/USDT) or use `get_data.py` to download top trading pairs from Binance.
+2. Configure the model with `window_size = 168`.
 3. Train the model using `train_rl.py`.
 4. Analyze trading performance using the detailed and summary reports.
 

--- a/config.json
+++ b/config.json
@@ -15,5 +15,10 @@
   "consecutive_no_trade_allowed": 10,
   "train_timesteps": 500000,
   "learn_timesteps": 10000,
-  "logging_level": "INFO"
+  "logging_level": "INFO",
+  "data_top_n": 100,
+  "data_interval": "1h",
+  "data_start_date": "2022-01-01",
+  "data_end_date": "2025-01-15",
+  "data_output_file": "top_pairs_1h.csv"
 }

--- a/env/hourly_trading_env.py
+++ b/env/hourly_trading_env.py
@@ -1,86 +1,19 @@
 """
-environment.py
+HourlyTradingEnv
 
-An advanced Gymnasium environment for hourly trading:
-- Multi-bar holding
-- Commission + slippage
-- SL/TP checks each step
-- Partial closes
-- Penalty for no-trade
-- Forced closure of all remaining trades at the end of the episode
-- NOW with "random start" in reset(), so each episode may start from a random index.
+A custom Gymnasium environment simulating trading on hourly candlesticks.
+Observation consists only of current balance.
 """
-
 import numpy as np
 import pandas as pd
 import gymnasium as gym
 from gymnasium import spaces
 from typing import List, Optional
 
-class Trade:
-    """
-    Stores info about a single trade (long or short).
-    """
-    def __init__(
-        self,
-        direction: str,       # 'long' or 'short'
-        entry_bar: int,
-        entry_price: float,
-        size_in_coins: float,
-        stop_loss: float,
-        take_profit: float
-    ):
-        self.direction = direction
-        self.entry_bar = entry_bar
-        self.entry_price = entry_price
-        self.size_in_coins = size_in_coins
-        self.stop_loss = stop_loss
-        self.take_profit = take_profit
-
-        self.exit_bar: Optional[int] = None
-        self.exit_price: Optional[float] = None
-        self.pnl: float = 0.0
-        self.closed: bool = False
-
-    def close(self, exit_bar: int, exit_price: float):
-        """
-        Closes the trade at exit_price and computes final PnL.
-        """
-        self.exit_bar = exit_bar
-        self.exit_price = exit_price
-        self.closed = True
-
-        if self.direction == 'long':
-            self.pnl = (self.exit_price - self.entry_price) * self.size_in_coins
-        else:  # short
-            self.pnl = (self.entry_price - self.exit_price) * abs(self.size_in_coins)
-
-    def __str__(self):
-        """
-        For easy debugging/printing.
-        """
-        return (f"Trade(dir={self.direction}, entry_bar={self.entry_bar}, "
-                f"exit_bar={self.exit_bar}, entry_price={self.entry_price:.2f}, "
-                f"exit_price={self.exit_price}, size={self.size_in_coins:.4f}, "
-                f"pnl={self.pnl:.2f}, closed={self.closed})")
+from trade import Trade
 
 
 class HourlyTradingEnv(gym.Env):
-    """
-    A custom Gymnasium environment simulating trading on hourly candlesticks.
-
-    Observations:
-      - A window of size `window_size` with [close, volume, atr]
-      - Current balance
-      - Total coins (long positive, short negative)
-
-    Actions (float array of length 5):
-      [open_long_frac, open_short_frac, close_fraction, sl_factor, tp_factor]
-    
-    We do "random start" in reset(), combined with max_bars=..., so each episode
-    covers a random slice of up to `max_bars` bars.
-    """
-
     def __init__(
         self,
         df: pd.DataFrame,
@@ -94,7 +27,7 @@ class HourlyTradingEnv(gym.Env):
         no_trade_penalty: float = 0.1,
         consecutive_no_trade_allowed: int = 10
     ):
-        super(HourlyTradingEnv, self).__init__()
+        super().__init__()
 
         self.df = df.reset_index(drop=True)
         self.n_bars = len(self.df)
@@ -115,19 +48,15 @@ class HourlyTradingEnv(gym.Env):
 
         # Internal states
         self.current_bar: int = 0
-        self.start_bar: int = 0  # <=== We'll store random start for each episode
+        self.start_bar: int = 0
         self.balance: float = 0.0
         self.open_trades: List[Trade] = []
         self.trade_log: List[Trade] = []
         self.consecutive_no_trade_steps = 0
 
-        # We'll use [close, volume, atr] as features
-        self.indicator_names = ['close', 'volume', 'atr']
-        self.num_features = len(self.indicator_names)
-
-        obs_dim = self.window_size * self.num_features + 2  # + balance, + total_coins
+        # Observation is just the balance
         self.observation_space = spaces.Box(
-            low=-np.inf, high=np.inf, shape=(obs_dim,), dtype=np.float32
+            low=-np.inf, high=np.inf, shape=(1,), dtype=np.float32
         )
 
         # [open_long_frac, open_short_frac, close_fraction, sl_factor, tp_factor]
@@ -137,9 +66,6 @@ class HourlyTradingEnv(gym.Env):
         )
 
     def _get_total_coins(self) -> float:
-        """
-        Returns net coins from all open trades (long positive, short negative).
-        """
         total = 0.0
         for t in self.open_trades:
             if not t.closed:
@@ -147,89 +73,43 @@ class HourlyTradingEnv(gym.Env):
         return total
 
     def _get_obs(self) -> np.ndarray:
-        """
-        Builds the observation from the last `window_size` bars + [balance, total_coins].
-        """
-        # current_bar goes from start_bar to (start_bar + max_bars)
-        # But for slicing features we just do: [current_bar - window_size : current_bar]
-        start_idx = max(self.current_bar - self.window_size, 0)
-        window_df = self.df.iloc[start_idx:self.current_bar]
-
-        if len(window_df) < self.window_size:
-            diff = self.window_size - len(window_df)
-            if len(window_df) == 0:
-                first_row = self.df.iloc[0]
-            else:
-                first_row = window_df.iloc[0]
-            pad_df = pd.DataFrame([first_row]*diff)
-            window_df = pd.concat([pad_df, window_df], ignore_index=True)
-
-        data_list = []
-        for col in self.indicator_names:
-            data_list.append(window_df[col].values)
-        data_array = np.array(data_list).flatten()
-
-        total_coins = self._get_total_coins()
-        obs = np.concatenate([data_array, [self.balance], [total_coins]])
-        return obs.astype(np.float32)
+        return np.array([self.balance], dtype=np.float32)
 
     def reset(self, seed=None, options=None):
-        """
-        Random start approach:
-          - pick random start_bar in [window_size, n_bars - max_bars], if possible
-          - set current_bar = start_bar
-        """
         super().reset(seed=seed)
         self.open_trades.clear()
         self.trade_log.clear()
         self.consecutive_no_trade_steps = 0
         self.balance = self.initial_balance
 
-        # 1) Calculate how many bars we can shift
         if self.max_bars is not None:
-            # we want start_bar + max_bars <= n_bars
-            # => start_bar <= n_bars - max_bars
             max_start = self.n_bars - self.max_bars
         else:
-            # if max_bars is None, we can in theory start anywhere
-            max_start = self.n_bars - 1  # or so
+            max_start = self.n_bars - 1
 
         min_start = self.window_size
-
         if max_start < min_start:
-            # if dataset is too small or max_bars is too large
-            # fallback to just start = window_size
             self.start_bar = self.window_size
         else:
-            # pick random start (high is exclusive, so add 1 to include max_start)
             self.start_bar = self.np_random.integers(low=min_start, high=max_start + 1)
 
-        # 2) Now set current_bar at start_bar
         self.current_bar = self.start_bar
-
-        # 3) Build first observation
         obs = self._get_obs()
         info = {}
         return obs, info
 
     def step(self, action: np.ndarray):
-        """
-        Step method:
-        action = [open_long_frac, open_short_frac, close_fraction, sl_factor, tp_factor]
-        """
-        open_long_frac  = float(action[0])
-        open_short_frac = float(action[1])
-        close_fraction  = float(action[2])
-        sl_factor       = float(action[3])
-        tp_factor       = float(action[4])
+        open_long_frac, open_short_frac, close_fraction, sl_factor, tp_factor = (
+            float(action[0]),
+            float(action[1]),
+            float(action[2]),
+            float(action[3]),
+            float(action[4]),
+        )
 
-        # Check if out of dataset
         if self.current_bar >= self.n_bars:
             obs = self._get_obs()
-            reward = 0.0
-            terminated = True
-            truncated = False
-            return obs, reward, terminated, truncated, {}
+            return obs, 0.0, True, False, {}
 
         terminated = False
         truncated = False
@@ -242,11 +122,10 @@ class HourlyTradingEnv(gym.Env):
 
         closed_trades = []
 
-        # =============== 1) Check SL/TP ===============
+        # ======= 1) Check SL/TP =======
         for trade in self.open_trades:
             if trade.closed:
                 continue
-
             if trade.direction == 'long':
                 if l <= trade.stop_loss:
                     exec_price = trade.stop_loss * (1.0 - self.slippage_rate)
@@ -262,8 +141,7 @@ class HourlyTradingEnv(gym.Env):
                     trade.pnl -= fee
                     self.balance += trade.pnl
                     closed_trades.append(trade)
-
-            else:  # short
+            else:
                 if h >= trade.stop_loss:
                     exec_price = trade.stop_loss * (1.0 + self.slippage_rate)
                     trade.close(bar_idx, exec_price)
@@ -279,7 +157,7 @@ class HourlyTradingEnv(gym.Env):
                     self.balance += trade.pnl
                     closed_trades.append(trade)
 
-        # =============== 2) Partial close ===============
+        # ======= 2) Partial close =======
         if close_fraction > 1e-8:
             for trade in self.open_trades:
                 if trade.closed:
@@ -287,30 +165,25 @@ class HourlyTradingEnv(gym.Env):
                 coins_to_close = trade.size_in_coins * close_fraction
                 if abs(coins_to_close) < 1e-8:
                     continue
-
                 if trade.direction == 'long':
                     exec_price = c * (1.0 - self.slippage_rate)
                     partial_pnl = (exec_price - trade.entry_price) * coins_to_close
                 else:
                     exec_price = c * (1.0 + self.slippage_rate)
                     partial_pnl = (trade.entry_price - exec_price) * abs(coins_to_close)
-
                 fee = abs(exec_price * coins_to_close) * self.commission_rate
                 partial_pnl -= fee
-
                 self.balance += partial_pnl
                 trade.pnl += partial_pnl
                 trade.size_in_coins -= coins_to_close
-
                 if abs(trade.size_in_coins) < 1e-8:
                     trade.closed = True
                     trade.exit_bar = bar_idx
                     trade.exit_price = exec_price
                     closed_trades.append(trade)
 
-        # =============== 3) Possibly open trades ===============
+        # ======= 3) Possibly open trades =======
         no_trade_this_step = True
-
         if open_long_frac > 1e-8 and open_short_frac < 1e-8:
             invest_amount = self.balance * open_long_frac
             if invest_amount > 0:
@@ -318,7 +191,6 @@ class HourlyTradingEnv(gym.Env):
                 size_in_coins = invest_amount / entry_price
                 sl_price = entry_price - sl_factor * atr_val
                 tp_price = entry_price + tp_factor * atr_val
-
                 new_trade = Trade(
                     direction='long',
                     entry_bar=bar_idx,
@@ -331,9 +203,7 @@ class HourlyTradingEnv(gym.Env):
                 self.trade_log.append(new_trade)
                 fee = invest_amount * self.commission_rate
                 self.balance -= fee
-
                 no_trade_this_step = False
-
         elif open_short_frac > 1e-8 and open_long_frac < 1e-8:
             invest_amount = self.balance * open_short_frac
             if invest_amount > 0:
@@ -341,7 +211,6 @@ class HourlyTradingEnv(gym.Env):
                 size_in_coins = - invest_amount / entry_price
                 sl_price = entry_price + sl_factor * atr_val
                 tp_price = entry_price - tp_factor * atr_val
-
                 new_trade = Trade(
                     direction='short',
                     entry_bar=bar_idx,
@@ -354,37 +223,30 @@ class HourlyTradingEnv(gym.Env):
                 self.trade_log.append(new_trade)
                 fee = invest_amount * self.commission_rate
                 self.balance -= fee
-
                 no_trade_this_step = False
 
         step_closed_pnl = sum(t.pnl for t in closed_trades)
         reward = step_closed_pnl * self.reward_scaling
 
-        # penalty for no-trade
+        # penalty for no-trade: reduce balance and reward
         if no_trade_this_step:
             self.consecutive_no_trade_steps += 1
-            if (self.penalize_no_trade_steps and
-                self.consecutive_no_trade_steps > self.consecutive_no_trade_allowed):
+            if self.penalize_no_trade_steps:
+                self.balance -= self.no_trade_penalty
                 reward -= self.no_trade_penalty
+                if self.consecutive_no_trade_steps > self.consecutive_no_trade_allowed:
+                    reward -= self.no_trade_penalty
         else:
             self.consecutive_no_trade_steps = 0
 
-        # advance bar
         self.current_bar += 1
 
-        # check truncated if max_bars
-        truncated = False
         if self.max_bars is not None:
-            # how many bars have we used in this episode so far?
-            # used_bars = self.current_bar - self.start_bar
             used_bars = self.current_bar - self.start_bar
             if used_bars >= self.max_bars:
                 truncated = True
-
-        # check terminated if out of dataset
-        terminated = (self.current_bar >= self.n_bars)
-
-        # bankrupt?
+        if self.current_bar >= self.n_bars:
+            terminated = True
         if self.balance <= 0.0:
             terminated = True
             reward -= 1000.0 * self.reward_scaling
@@ -392,12 +254,9 @@ class HourlyTradingEnv(gym.Env):
         obs = self._get_obs()
         info = {}
 
-        # force close if done
         if terminated or truncated:
-            print("[DEBUG] End of episode. Forcing closure of open trades.")
             additional_pnl = 0.0
-            forced_close_count = 0
-            c_price = c  # bar's close
+            c_price = c
             for trade in self.open_trades:
                 if not trade.closed:
                     if trade.direction == 'long':
@@ -409,13 +268,8 @@ class HourlyTradingEnv(gym.Env):
                     trade.pnl -= fee
                     additional_pnl += trade.pnl
                     trade.closed = True
-                    forced_close_count += 1
-                    print(f"[DEBUG] ForceClosed trade: {trade}")
-
             self.balance += additional_pnl
             reward += additional_pnl * self.reward_scaling
-            print(f"[DEBUG] Forced close {forced_close_count} trades at end. additional_pnl={additional_pnl:.2f}")
-            print(f"[DEBUG] final balance after forced close = {self.balance:.2f}")
 
         return obs, reward, terminated, truncated, info
 

--- a/get_data.py
+++ b/get_data.py
@@ -1,58 +1,92 @@
-import requests
-import pandas as pd
-from datetime import datetime, timedelta
+import json
 import time
+from datetime import datetime
+from typing import List
 
-# Specify parameters
-symbol = "BTCUSDT"
-interval = "5m"  # 5-minute interval
-start_date = "2022-01-01"  # start date for data collection
-end_date = "2025-01-15"    # end date for data collection
-output_file = "historical_data_1h.csv"
+import pandas as pd
+import requests
 
-# Function to convert a date string to milliseconds
-def date_to_milliseconds(date_str):
+# Load parameters from config
+with open("config.json", "r") as f:
+    config = json.load(f)
+
+TOP_N = config.get("data_top_n", 100)
+INTERVAL = config.get("data_interval", "1h")
+START_DATE = config.get("data_start_date")
+END_DATE = config.get("data_end_date")
+OUTPUT_FILE = config.get("data_output_file", "top_pairs_1h.csv")
+
+
+def date_to_milliseconds(date_str: str) -> int:
     dt = datetime.strptime(date_str, "%Y-%m-%d")
     return int(dt.timestamp() * 1000)
 
-# Fetch historical data from Binance API
-def fetch_binance_data(symbol, interval, start_time, end_time, limit=1000):
+
+def get_top_symbols(limit: int) -> List[str]:
+    url = "https://api.binance.com/api/v3/ticker/24hr"
+    resp = requests.get(url)
+    data = resp.json()
+    df = pd.DataFrame(data)
+    df['quoteVolume'] = df['quoteVolume'].astype(float)
+    df.sort_values(by='quoteVolume', ascending=False, inplace=True)
+    return df['symbol'].head(limit).tolist()
+
+
+def fetch_binance_data(symbol: str, interval: str, start_time: int, end_time: int, limit: int = 1000):
     url = "https://api.binance.com/api/v3/klines"
     params = {
         "symbol": symbol,
         "interval": interval,
         "startTime": start_time,
         "endTime": end_time,
-        "limit": limit
+        "limit": limit,
     }
     response = requests.get(url, params=params)
-    data = response.json()
-    return data
+    return response.json()
 
-# Convert dates to milliseconds
-start_time = date_to_milliseconds(start_date)
-end_time = date_to_milliseconds(end_date)
-all_data = []
 
-while start_time < end_time:
-    data = fetch_binance_data(symbol, interval, start_time, end_time)
-    if not data:
-        break
-    all_data.extend(data)
-    
-    # Update start_time for the next request (advance by one interval)
-    start_time = data[-1][0] + (5 * 60 * 1000)
-    time.sleep(0.1)  # delay to avoid API rate limits
+def fetch_symbol_history(symbol: str, start_ms: int, end_ms: int) -> pd.DataFrame:
+    all_data = []
+    start = start_ms
+    while start < end_ms:
+        data = fetch_binance_data(symbol, INTERVAL, start, end_ms)
+        if not data:
+            break
+        all_data.extend(data)
+        start = data[-1][0] + 1
+        time.sleep(0.1)
+    if not all_data:
+        return pd.DataFrame()
+    df = pd.DataFrame(
+        all_data,
+        columns=[
+            "timestamp", "open", "high", "low", "close", "volume",
+            "close_time", "quote_asset_volume", "number_of_trades",
+            "taker_buy_base_asset_volume", "taker_buy_quote_asset_volume", "ignore",
+        ],
+    )
+    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+    df = df[["timestamp", "open", "high", "low", "close", "volume"]]
+    df["symbol"] = symbol
+    return df
 
-# Convert data to a DataFrame and save to CSV
-df = pd.DataFrame(all_data, columns=[
-    "timestamp", "open", "high", "low", "close", "volume",
-    "close_time", "quote_asset_volume", "number_of_trades",
-    "taker_buy_base_asset_volume", "taker_buy_quote_asset_volume", "ignore"
-])
-df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")  # convert timestamps to datetime
 
-# Keep only the required columns
-df = df[["timestamp", "open", "high", "low", "close", "volume"]]
-df.to_csv(output_file, index=False)
-print(f"Historical 5-minute data has been saved to {output_file}")
+def main():
+    symbols = get_top_symbols(TOP_N)
+    start_ms = date_to_milliseconds(START_DATE)
+    end_ms = date_to_milliseconds(END_DATE)
+    frames = []
+    for sym in symbols:
+        df = fetch_symbol_history(sym, start_ms, end_ms)
+        if not df.empty:
+            frames.append(df)
+    if frames:
+        result = pd.concat(frames, ignore_index=True)
+        result.to_csv(OUTPUT_FILE, index=False)
+        print(f"Saved data for {len(frames)} symbols to {OUTPUT_FILE}")
+    else:
+        print("No data fetched")
+
+
+if __name__ == "__main__":
+    main()

--- a/paper_trading.py
+++ b/paper_trading.py
@@ -7,7 +7,7 @@ import csv, os
 from datetime import datetime, timedelta
 from binance import Client
 from stable_baselines3 import PPO
-from environment import HourlyTradingEnv
+from env.hourly_trading_env import HourlyTradingEnv
 
 # Загрузка конфигурации из JSON
 with open("config.json", "r") as f:

--- a/trade.py
+++ b/trade.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+
+class Trade:
+    """Stores info about a single trade (long or short)."""
+
+    def __init__(
+        self,
+        direction: str,       # 'long' or 'short'
+        entry_bar: int,
+        entry_price: float,
+        size_in_coins: float,
+        stop_loss: float,
+        take_profit: float
+    ):
+        self.direction = direction
+        self.entry_bar = entry_bar
+        self.entry_price = entry_price
+        self.size_in_coins = size_in_coins
+        self.stop_loss = stop_loss
+        self.take_profit = take_profit
+
+        self.exit_bar: Optional[int] = None
+        self.exit_price: Optional[float] = None
+        self.pnl: float = 0.0
+        self.closed: bool = False
+
+    def close(self, exit_bar: int, exit_price: float):
+        """Closes the trade at exit_price and computes final PnL."""
+        self.exit_bar = exit_bar
+        self.exit_price = exit_price
+        self.closed = True
+
+        if self.direction == 'long':
+            self.pnl = (self.exit_price - self.entry_price) * self.size_in_coins
+        else:  # short
+            self.pnl = (self.entry_price - self.exit_price) * abs(self.size_in_coins)
+
+    def __str__(self):
+        """For easy debugging/printing."""
+        return (
+            f"Trade(dir={self.direction}, entry_bar={self.entry_bar}, "
+            f"exit_bar={self.exit_bar}, entry_price={self.entry_price:.2f}, "
+            f"exit_price={self.exit_price}, size={self.size_in_coins:.4f}, "
+            f"pnl={self.pnl:.2f}, closed={self.closed})"
+        )

--- a/train_rl.py
+++ b/train_rl.py
@@ -15,7 +15,7 @@ import json
 import pandas as pd
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import DummyVecEnv
-from environment import HourlyTradingEnv
+from env.hourly_trading_env import HourlyTradingEnv
 
 # Загрузка конфигурации из JSON
 with open("config.json", "r") as f:

--- a/tune_hyperparams.py
+++ b/tune_hyperparams.py
@@ -1,0 +1,72 @@
+"""Simple hyperparameter tuning for PPO using Optuna."""
+import json
+
+import optuna
+import pandas as pd
+from stable_baselines3 import PPO
+from stable_baselines3.common.evaluation import evaluate_policy
+from stable_baselines3.common.vec_env import DummyVecEnv
+
+from env.hourly_trading_env import HourlyTradingEnv
+
+# Load configuration
+with open("config.json", "r") as f:
+    config = json.load(f)
+
+# Load data
+DF = pd.read_csv("historical_data_1h.csv")
+
+REQUIRED_COLS = ["open", "high", "low", "close", "volume"]
+for col in REQUIRED_COLS:
+    if col not in DF.columns:
+        raise ValueError(f"Column '{col}' not found in CSV.")
+DF.reset_index(drop=True, inplace=True)
+
+
+def make_env():
+    return HourlyTradingEnv(
+        df=DF,
+        window_size=config["window_size"],
+        initial_balance=config["initial_balance"],
+        commission_rate=config["commission_rate"],
+        slippage_rate=config["slippage_rate"],
+        max_bars=config["max_bars"],
+        reward_scaling=config["reward_scaling"],
+        penalize_no_trade_steps=config["penalize_no_trade_steps"],
+        no_trade_penalty=config["no_trade_penalty"],
+        consecutive_no_trade_allowed=config["consecutive_no_trade_allowed"],
+    )
+
+
+def objective(trial: optuna.Trial) -> float:
+    env = DummyVecEnv([make_env])
+    learning_rate = trial.suggest_float("learning_rate", 1e-5, 1e-2, log=True)
+    gamma = trial.suggest_float("gamma", 0.9, 0.9999)
+    batch_size = trial.suggest_categorical("batch_size", [64, 128, 256])
+    n_steps = trial.suggest_categorical("n_steps", [128, 256, 512])
+
+    model = PPO(
+        "MlpPolicy",
+        env,
+        learning_rate=learning_rate,
+        gamma=gamma,
+        batch_size=batch_size,
+        n_steps=n_steps,
+        verbose=0,
+    )
+    model.learn(total_timesteps=max(1000, config["train_timesteps"] // 10))
+    mean_reward, _ = evaluate_policy(model, env, n_eval_episodes=1)
+    env.close()
+    return mean_reward
+
+
+def main():
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=10)
+    with open("best_params.json", "w") as f:
+        json.dump(study.best_params, f, indent=2)
+    print("Best params saved to best_params.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- split Trade and environment classes into separate modules
- simplify observations to balance-only and apply balance penalty on idle steps
- add scripts for fetching top Binance pairs and tuning PPO hyperparameters

## Testing
- `pytest`
- `python -m py_compile trade.py env/hourly_trading_env.py train_rl.py paper_trading.py get_data.py tune_hyperparams.py`


------
https://chatgpt.com/codex/tasks/task_e_6899dcb0597c832683770e189751b29e