### PR TITLE
Fix short trade cash flow and stabilize episode horizon

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
   "initial_balance": 1000.0,
   "commission_rate": 0.0004,
   "slippage_rate": 0.0002,
-  "max_bars": 2000,
+  "max_bars": 512,
   "reward_scaling": 1.0,
   "penalize_no_trade_steps": true,
   "no_trade_penalty": 0.1,


### PR DESCRIPTION
## Summary
- ensure reset picks a start bar with guaranteed horizon and set default max_bars to 512
- prevent zero ATR issues, cap per-trade allocation, and credit balance on shorts
- compute rewards from log equity changes for clearer learning signal

## Testing
- `python -m py_compile env/hourly_trading_env.py`
- `python -m json.tool config.json`
- `pytest`
- `python - <<'PY' ...` (smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68a31f8a1ed08326bd6ab68e170e0e5c