### PR TITLE
Use log-normalized features and ATR-based position sizing

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,6 +13,8 @@
   "slippage_rate": 0.0002,
   "max_bars": 512,
   "reward_scaling": 1.0,
+  "risk_fraction": 0.01,
+  "max_alloc_per_trade": 0.3,
   "penalize_no_trade_steps": true,
   "no_trade_penalty": 0.1,
   "consecutive_no_trade_allowed": 10,

--- a/train_rl.py
+++ b/train_rl.py
@@ -171,6 +171,8 @@ def make_env_from_df(df: pd.DataFrame) -> DummyVecEnv:
         ma_short_window=config["ma_short_window"],
         ma_long_window=config["ma_long_window"],
         vol_ma_window=config["vol_ma_window"],
+        risk_fraction=config.get("risk_fraction", 0.01),
+        max_alloc_per_trade=config.get("max_alloc_per_trade", 0.3),
     )
     env = Monitor(env)  # важно: чтобы получать info['episode'] для метрик
     venv = DummyVecEnv([lambda: env])


### PR DESCRIPTION
## Summary
- Replace mixed ratio/log observation with six log-normalized features
- Rework trade settlement to reserve margin and return 2× notional when closing shorts
- Implement ATR-based position sizing with netted orders and a minimum-notional guard
- Recompute long position size after notional clipping and enforce bankruptcy stop
- Recalculate equity after forced closes and pass configurable risk parameters

## Testing
- `python -m py_compile env/hourly_trading_env.py train_rl.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a342977ed08326ba5381167ae0ca5b