### PR TITLE
feat: centralize training outputs and fix log warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 venv/
-tensorboard_logs/
+runs/
 __pycache__/
 ppo_hourly_model*
 *.csv
 *.DS_Store
 test.py
 *.log
+# legacy dirs
 logs/
+tensorboard_logs/
 checkpoints/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository demonstrates how to train a reinforcement learning (RL) agent us
   - Creates and wraps the environment.
   - Trains a PPO agent.
   - Runs a quick test and prints final results.
+  - Stores checkpoints, logs and TensorBoard data under `runs/`.
 
 ---
 
@@ -81,7 +82,7 @@ python train_rl.py
 ### Monitor Logs
 - Check training progress in the console or via TensorBoard:
   ```bash
-  tensorboard --logdir ./tensorboard_logs/
+  tensorboard --logdir ./runs/tensorboard/
   ```
 
 ### Analyze Results
@@ -91,7 +92,7 @@ python train_rl.py
 
 ## Output
 
-- **Trained Model**: Saved to `ppo_hourly_model.zip` for future use.
+- **Trained Model**: Saved to `runs/ppo_hourly_model.zip` for future use.
 - **Reports**:
   - **Detailed Report**: Logs individual trade metrics, including timestamps, thresholds, positions, and balances.
   - **Summary Report**: Aggregates metrics like total trades, success rates, and final balance.


### PR DESCRIPTION
## Summary
- prevent divide-by-zero warnings in volume normalization by using a safe log-ratio
- consolidate logs, checkpoints, TensorBoard data and model under `runs/`
- silence protobuf/TensorFlow warnings for cleaner training output

## Testing
- `python -m py_compile env/hourly_trading_env.py train_rl.py`
- `python - <<'PY'\nimport train_rl\nprint('imported train_rl')\nPY` *(fails: FileNotFoundError: Не нашёл CSV)*

------
https://chatgpt.com/codex/tasks/task_e_68a40a9be5148326972913e2d1c384b2